### PR TITLE
Update Slack login flow to align with how Web App works today

### DIFF
--- a/login_details.go
+++ b/login_details.go
@@ -14,13 +14,14 @@ import (
 	"golang.org/x/net/html/atom"
 )
 
-// LoginDetails is a struct to contain the hidden presented by Slack on their
-// login form. Some of these fields are needed for logging in, so this can be
-// used to present them back.
+// LoginDetails is a struct to contain the hidden fields presented by Slack on
+// their login form. Some of these fields are needed for logging in, so this can
+// be used to present them back.
 type LoginDetails struct {
-	Crumb  string
-	Redir  string
-	Signin string
+	Crumb       string
+	Redir       string
+	Signin      string
+	HasRemember string
 }
 
 func (c *Client) getLoginDetails() (LoginDetails, bool, error) {
@@ -99,6 +100,8 @@ func parseLoginDetails(r io.Reader) (LoginDetails, error) {
 			ld.Redir = attribs["value"]
 		case "signin":
 			ld.Signin = attribs["value"]
+		case "has_remember":
+			ld.HasRemember = attribs["value"]
 		default:
 			// not a known tag, move on
 			continue

--- a/login_details_test.go
+++ b/login_details_test.go
@@ -20,9 +20,10 @@ const (
 )
 
 const (
-	tdLoginDetailsCrumb  = `s-1523681453-a17c4e9381e3df00d5e13491ef4608bde2b0f4c7c185fe5ed080b2339920b2f3-☃`
-	tdLoginDetailsRedir  = `/customize/emoji`
-	tdLoginDetailsSignin = `1`
+	tdLoginDetailsCrumb       = `s-1523681453-a17c4e9381e3df00d5e13491ef4608bde2b0f4c7c185fe5ed080b2339920b2f3-☃`
+	tdLoginDetailsRedir       = `/customize/emoji`
+	tdLoginDetailsSignin      = `1`
+	tdLoginDetailsHasRemember = `2`
 )
 
 func Test_parseLoginDetails(t *testing.T) {
@@ -73,6 +74,10 @@ func Test_parseLoginDetails(t *testing.T) {
 
 			if ld.Signin != tdLoginDetailsSignin {
 				t.Fatalf("ld.Signin = %q, want %q", ld.Signin, tdLoginDetailsSignin)
+			}
+
+			if ld.HasRemember != tdLoginDetailsHasRemember {
+				t.Fatalf("ld.HasRemember' = %q, want %q", ld.HasRemember, tdLoginDetailsHasRemember)
 			}
 		})
 	}

--- a/mech.go
+++ b/mech.go
@@ -289,13 +289,20 @@ func (c *Client) logIn(email, password string, ld LoginDetails) (string, error) 
 		return "", errors.New("LoginDetails must contain a signin value")
 	}
 
+	// make sure the has_remember value is provided
+	if len(ld.HasRemember) == 0 {
+		return "", errors.New("LoginDetails must contain a has_remember value")
+	}
+
 	// build the form data for the login POST request
 	v := url.Values{
-		"crumb":    []string{ld.Crumb},
-		"email":    []string{email},
-		"password": []string{password},
-		"redir":    []string{ld.Redir},
-		"signin":   []string{ld.Signin},
+		"crumb":        []string{ld.Crumb},
+		"email":        []string{email},
+		"password":     []string{password},
+		"redir":        []string{ld.Redir},
+		"signin":       []string{ld.Signin},
+		"has_remember": []string{ld.HasRemember},
+		"remember":     []string{"on"}, // we will not be forgotten
 	}
 
 	// post the form data to the login URL

--- a/testdata/login_details.html
+++ b/testdata/login_details.html
@@ -1,7 +1,8 @@
 <form id="signin_form" action="/" method="post" accept-encoding="UTF-8">
   <input type="hidden" name="signin" value="1">
   <input type="hidden" name="redir" value="/customize/emoji">
-  <input type="hidden" name="crumb" value="s-1523681453-a17c4e9381e3df00d5e13491ef4608bde2b0f4c7c185fe5ed080b2339920b2f3-☃" />
+  <input type="hidden" name="has_remember" value="2"> <!-- not the actual value presented by Slack -->
+  <input type="hidden" name="crumb" value="s-1523681453-a17c4e9381e3df00d5e13491ef4608bde2b0f4c7c185fe5ed080b2339920b2f3-☃">
   <p class="browser_password align_left">Enter your <strong>email address</strong> and <strong>password</strong>.</p>
   <p class="ssb_password hidden">What is your <strong>password</strong>?</p>
   <p class=" no_bottom_margin">

--- a/testdata/start_session.html
+++ b/testdata/start_session.html
@@ -1,7 +1,8 @@
 <form id="signin_form" action="/" method="post" accept-encoding="UTF-8">
   <input type="hidden" name="signin" value="1">
   <input type="hidden" name="redir" value="">
-  <input type="hidden" name="crumb" value="s-1523681454-a17c4e9381e3df00d5e13491ef4608bde2b0f4c7c185fe5ed080b2339920b2f3-☃" />
+  <input type="hidden" name="has_remember" value="2"> <!-- not the actual value presented by Slack -->
+  <input type="hidden" name="crumb" value="s-1523681454-a17c4e9381e3df00d5e13491ef4608bde2b0f4c7c185fe5ed080b2339920b2f3-☃">
   <p class="browser_password align_left">Enter your <strong>email address</strong> and <strong>password</strong>.</p>
   <p class="ssb_password hidden">What is your <strong>password</strong>?</p>
   <p class=" no_bottom_margin">


### PR DESCRIPTION
I discovered that Slack has made some changes to how the login works (in terms
of hidden fields exposed/sent).

- login form now has a `has_remember` hidden field
- send the value indicating that we want to be remembered

This also updates the tests to appropriately exercise the code that handles
parsing those values out.

Signed-off-by: Tim Heckman <t@heckman.io>