### PR TITLE
Install golangci-lint and use it in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: go
 go:
-- 1.9.5
-- 1.10.1
+- 1.10.x
+- 1.11.x
 sudo: false
 notifications:
   email:
     on_success: never
     on_failure: always
+before_install:
+  - make install_linter
+  - golangci-lint --version
 install: true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 .DEFAULT_GOAL := test
 
-test:
-	go test -v -covermode=count -coverprofile=profile.out .
+GOPATH := $(shell go env GOPATH)
+
+lint:
+	golangci-lint run .
+
+test: lint
+	go test -v -cover -covermode atomic -coverprofile profile.out .
+
+install_linter:
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.12.5
 
 .PHONY: test


### PR DESCRIPTION
This updates the `Makefile` to include a build target that installs
`golangci-lint` and one to run it. The `test` build target also now runs the
linter by default.

This will fail the build on `master` at the time of commit, and will be used to
test an incoming PR's linter fixes.

Signed-off-by: Tim Heckman <t@heckman.io>