### PR TITLE
Fix linting issues reported by golangci-lint

### DIFF
--- a/login_details.go
+++ b/login_details.go
@@ -30,7 +30,7 @@ func (c *Client) getLoginDetails() (LoginDetails, bool, error) {
 		return LoginDetails{}, false, err
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // appease errcheck
 
 	switch resp.StatusCode {
 	default:

--- a/login_details_test.go
+++ b/login_details_test.go
@@ -47,7 +47,7 @@ func Test_parseLoginDetails(t *testing.T) {
 				t.Fatalf("failed to open %q: %s", tt.fn, err)
 			}
 
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 
 			ld, err = parseLoginDetails(f)
 			if err != nil {
@@ -162,12 +162,12 @@ func muxGetLoginDetails(t *testing.T) *http.ServeMux {
 
 	mux.HandleFunc("/bad_response_code", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
-		io.WriteString(w, "SHOULD CAUSE ERROR")
+		_, _ = io.WriteString(w, "SHOULD CAUSE ERROR") // appease errcheck
 	})
 
 	mux.HandleFunc("/another_bad_response_code", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusLoopDetected)
-		io.WriteString(w, "SHOULD CAUSE ERROR")
+		_, _ = io.WriteString(w, "SHOULD CAUSE ERROR") // appease errcheck
 	})
 
 	mux.HandleFunc("/logged_in", func(w http.ResponseWriter, r *http.Request) {
@@ -184,7 +184,7 @@ func muxGetLoginDetails(t *testing.T) *http.ServeMux {
 			t.Fatalf("failed to open %q: %q", tdLoginDetails, err)
 		}
 
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		if _, err = io.Copy(w, f); err != nil {
 			t.Fatalf("failed to write body: %s", err)
@@ -197,7 +197,7 @@ func muxGetLoginDetails(t *testing.T) *http.ServeMux {
 			t.Fatalf("failed to open %q: %q", tdLoginDetailsMissingCrumb, err)
 		}
 
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		if _, err = io.Copy(w, f); err != nil {
 			t.Fatalf("failed to write body: %s", err)

--- a/session_details.go
+++ b/session_details.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	apiTokenString   = `api_token: "`
+	apiTokenString   = `api_token: "` /* #nosec */
 	logOutURLString  = `boot_data.logout_url = "`
 	versionTSstring  = `version_ts: "`
 	versionUIDstring = `version_uid: "`
@@ -38,7 +38,7 @@ func (c *Client) getSessionDetails() (sessionDetails, error) {
 		return sessionDetails{}, errors.Wrapf(err, "failed to get %q", url)
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return sessionDetails{}, errors.Errorf("unexpected HTTP response status: %s", resp.Status)

--- a/session_details_test.go
+++ b/session_details_test.go
@@ -34,11 +34,13 @@ func Test_formatLogoutURL(t *testing.T) {
 		},
 	}
 
+	var formatted string
+
 	for _, tt := range tests {
 		tt := tt
 
 		t.Run(tt.n, func(t *testing.T) {
-			var formatted string = formatLogoutURL(tt.i)
+			formatted = formatLogoutURL(tt.i)
 
 			if formatted != tt.o {
 				t.Errorf("formatLogoutURL(%q) = %q, want %q", tt.i, formatted, tt.o)
@@ -53,7 +55,7 @@ func Test_parseInlineJsValue(t *testing.T) {
 		t.Fatalf("error opening ./testdata/session_details.html: %s", err)
 	}
 
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	p, err := ioutil.ReadAll(f)
 	if err != nil {
@@ -104,7 +106,7 @@ func Test_parseInlineJsValue(t *testing.T) {
 // constants for paths to session details mock HTML files
 const (
 	tdSessionDetails                 = "./testdata/session_details.html"
-	tdSessionDetailsMissingToken     = "./testdata/session_details_missing_token.html"
+	tdSessionDetailsMissingToken     = "./testdata/session_details_missing_token.html" /* #nosec */
 	tdSessionDetailsMissingTS        = "./testdata/session_details_missing_ts.html"
 	tdSessionDetailsMissingUID       = "./testdata/session_details_missing_uid.html"
 	tdSessionDetailsMissingLogoutURL = "./testdata/session_details_missing_logout_url.html"
@@ -113,7 +115,7 @@ const (
 
 // constants for the important values from the session details mock HTML
 const (
-	tdSessionToken      = "xoxs-334538486097-REDACTED"
+	tdSessionToken      = "xoxs-334538486097-REDACTED" /* #nosec */
 	tdSessionVersionTS  = "1523401638"
 	tdSessionVersionUID = "960e24c8dab464c657ca8fd7318a5b5033fdc962"
 	tdSessionLogoutURL  = `https://slack.com/signout/334538486097?crumb=s-1523401174-affe372c8bde699088fc69fb5bbb9ce5aed6455a7f70ca04e3bb52c06984a263-%E2%98%83`
@@ -182,7 +184,7 @@ func Test_parseSessionDetails(t *testing.T) {
 					t.Fatalf("failed to open %q: %s", tt.fn, err)
 				}
 
-				defer f.Close()
+				defer func() { _ = f.Close() }()
 
 				r = f
 			}
@@ -308,7 +310,7 @@ func muxGetSessionDetails(t *testing.T) *http.ServeMux {
 			t.Fatalf("failed to open %q: %s", tdSessionDetailsMissingToken, err)
 		}
 
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		if _, err = io.Copy(w, f); err != nil {
 			t.Fatalf("failed to write body: %s", err)
@@ -320,7 +322,7 @@ func muxGetSessionDetails(t *testing.T) *http.ServeMux {
 			t.Fatalf("failed to open %q: %s", tdSessionDetailsMissingToken, err)
 		}
 
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		if _, err = io.Copy(w, f); err != nil {
 			t.Fatalf("failed to write body: %s", err)

--- a/util_test.go
+++ b/util_test.go
@@ -123,7 +123,7 @@ func Test_postFormReq(t *testing.T) {
 				t.Fatalf(`r.Header.Get("Content-Type") = %q, want expectedUserAgent`, ct)
 			}
 
-			defer r.Body.Close()
+			defer func() { _ = r.Body.Close() }()
 
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {


### PR DESCRIPTION
There were quite a few, but `errcheck` was the most noisy of them all.

Signed-off-by: Tim Heckman <t@heckman.io>